### PR TITLE
add release github workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,43 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Build and Release
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build OGStarTracker
+        run: pio run --project-dir esp32_wireless_control/firmware
+
+      - name: Upload Build Artifact
+        if: ${{ success() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: binaries
+          path: |
+            esp32_wireless_control/firmware/.pio/build/ogstartracker_release/ogstartracker*.bin
+
+      - name: Create release
+        if: ${{ success() }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ github.ref_name }}
+        run: |
+          gh release create "$tag_name" \
+            --repo="$GITHUB_REPOSITORY" \
+            --title="Release ${tag_name}" \
+            --generate-notes
+          gh release upload $tag_name \
+            esp32_wireless_control/firmware/.pio/build/ogstartracker_release/ogstartracker*.bin 


### PR DESCRIPTION
Automate the project workflow by introducing automatic release creation when a tag is pushed to the repository.
When a tag is created with `git tag -a <tag> -m "prepare <version>"` it will kick the action that builds the project and publishes the release with the binary attached to the release artifacts.

As a suggestion since the tags currently provided are behind the actual firmware version some tags need to be published in advance.

I will do that once this PR  and the previous PR's gets merged together with the webhooks introduction.