### PR TITLE
move static defines to config.h

### DIFF
--- a/esp32_wireless_control/firmware/.gitignore
+++ b/esp32_wireless_control/firmware/.gitignore
@@ -4,3 +4,4 @@
 .vscode/c_cpp_properties.json
 .vscode/launch.json
 .vscode/ipch
+compile_commands.json

--- a/esp32_wireless_control/firmware/axis.cpp
+++ b/esp32_wireless_control/firmware/axis.cpp
@@ -50,7 +50,7 @@ Axis::Axis(uint8_t axis, uint8_t dirPinforAxis, bool invertDirPin) : stepTimer(4
     trackingDirection = c_DIRECTION;
     dirPin = dirPinforAxis;
     invertDirectionPin = invertDirPin;
-    trackingRate = TRACKING_SIDEREAL;
+    trackingRate = TRACKING_RATE;
     switch (axisNumber)
     {
         case 1:
@@ -63,7 +63,7 @@ Axis::Axis(uint8_t axis, uint8_t dirPinforAxis, bool invertDirPin) : stepTimer(4
 
     if (DEFAULT_ENABLE_TRACKING == 1 && axisNumber == 1)
     {
-        startTracking(TRACKING_SIDEREAL, trackingDirection);
+        startTracking(trackingRate, trackingDirection);
     }
 }
 

--- a/esp32_wireless_control/firmware/config.h
+++ b/esp32_wireless_control/firmware/config.h
@@ -15,6 +15,24 @@
 #define STEPPER_0_9                  // uncomment this line if you have a 0.9 degree NEMA17
 // #define STEPPER_1_8   //uncomment this line if you have a 1.8 degree NEMA17, and comment the
 // above line
+
+// Configure the wifi settings if you are not using platformio
+#ifndef WIFI_SSID
+#define WIFI_SSID "OG Star Tracker" // change to your SSID
+#endif
+#ifndef WIFI_PASS
+#define WIFI_PASS "password123" // change to your password, must be 8+ characters
+#endif
+// If you are using AP mode, you can access the website using the below URL
+#ifndef WEBSITE_NAME
+#define WEBSITE_NAME "www.tracker.com"
+#endif
+#ifndef DNS_PORT
+#define DNS_PORT 53
+#endif
+#ifndef WEBSERVER_PORT
+#define WEBSERVER_PORT 80
+#endif
 /**********************/
 
 /*****DO NOT MODIFY BELOW*****/

--- a/esp32_wireless_control/firmware/config.h
+++ b/esp32_wireless_control/firmware/config.h
@@ -33,6 +33,11 @@
 #ifndef WEBSERVER_PORT
 #define WEBSERVER_PORT 80
 #endif
+
+// try to update every time there is breaking change
+#ifndef INTERNAL_VERSION
+#define INTERNAL_VERSION 7
+#endif
 /**********************/
 
 /*****DO NOT MODIFY BELOW*****/

--- a/esp32_wireless_control/firmware/config.h
+++ b/esp32_wireless_control/firmware/config.h
@@ -11,8 +11,8 @@
 #define DEC_INVERT_DIR_PIN 0         // if need to invert direction pin set to 1
 #define DEFAULT_ENABLE_TRACKING 0    // set to 1 to enable tracking at startup
 #define DITHER_DISTANCE_X10_PIXELS 5 // set max distance to dither in multiple of 10 pixels
-#define MAX_CUSTOM_SLEW_RATE 400     // Set max custom slew rate to  X tracking rate
-#define MIN_CUSTOM_SLEW_RATE 2       // Set min custom slew rate to  X tracking rate
+#define MAX_CUSTOM_SLEW_RATE 400     // Set max custom slew rate to X tracking rate
+#define MIN_CUSTOM_SLEW_RATE 2       // Set min custom slew rate to X tracking rate
 #define STEPPER_0_9                  // uncomment this line if you have a 0.9 degree NEMA17
 // #define STEPPER_1_8   //uncomment this line if you have a 1.8 degree NEMA17, and comment the
 // above line

--- a/esp32_wireless_control/firmware/config.h
+++ b/esp32_wireless_control/firmware/config.h
@@ -12,6 +12,7 @@
 #define DEFAULT_ENABLE_TRACKING 0    // set to 1 to enable tracking at startup
 #define DITHER_DISTANCE_X10_PIXELS 5 // set max distance to dither in multiple of 10 pixels
 #define MAX_CUSTOM_SLEW_RATE 400     // Set max custom slew rate to  X tracking rate
+#define MIN_CUSTOM_SLEW_RATE 2       // Set min custom slew rate to  X tracking rate
 #define STEPPER_0_9                  // uncomment this line if you have a 0.9 degree NEMA17
 // #define STEPPER_1_8   //uncomment this line if you have a 1.8 degree NEMA17, and comment the
 // above line

--- a/esp32_wireless_control/firmware/config.h
+++ b/esp32_wireless_control/firmware/config.h
@@ -17,6 +17,14 @@
 // #define STEPPER_1_8   //uncomment this line if you have a 1.8 degree NEMA17, and comment the
 // above line
 
+#ifndef TRACKING_RATE
+// Available tracking rates:
+// TRACKING_SIDEREAL
+// TRACKING_SOLAR
+// TRACKING_LUNAR
+#define TRACKING_RATE TRACKING_SIDEREAL // default tracking rate
+#endif
+
 // Configure the wifi settings if you are not using platformio
 #ifndef WIFI_SSID
 #define WIFI_SSID "OG Star Tracker" // change to your SSID

--- a/esp32_wireless_control/firmware/firmware.ino
+++ b/esp32_wireless_control/firmware/firmware.ino
@@ -13,8 +13,6 @@
 #include "web_languages.h"
 #include "website_strings.h"
 
-#define MIN_CUSTOM_SLEW_RATE 2
-
 unsigned long blink_millis = 0;
 
 WebServer server(WEBSERVER_PORT);

--- a/esp32_wireless_control/firmware/firmware.ino
+++ b/esp32_wireless_control/firmware/firmware.ino
@@ -13,9 +13,6 @@
 #include "web_languages.h"
 #include "website_strings.h"
 
-// try to update every time there is breaking change
-const int firmware_version = 7;
-
 #define MIN_CUSTOM_SLEW_RATE 2
 
 unsigned long blink_millis = 0;
@@ -257,7 +254,7 @@ void handleStatusRequest()
 
 void handleVersion()
 {
-    server.send(200, MIME_TYPE_TEXT, (String) firmware_version);
+    server.send(200, MIME_TYPE_TEXT, (String) INTERNAL_VERSION);
 }
 
 void setup()

--- a/esp32_wireless_control/firmware/firmware.ino
+++ b/esp32_wireless_control/firmware/firmware.ino
@@ -16,17 +16,11 @@
 // try to update every time there is breaking change
 const int firmware_version = 7;
 
-// Set your Wi-Fi credentials
-const byte DNS_PORT = 53;
-const char* ssid = "OG Star Tracker"; // change to your SSID
-const char* password = "password123"; // change to your password, must be 8+ characters
-// If you are using AP mode, you can access the website using the below URL
-const String website_name = "www.tracker.com";
 #define MIN_CUSTOM_SLEW_RATE 2
 
 unsigned long blink_millis = 0;
 
-WebServer server(80);
+WebServer server(WEBSERVER_PORT);
 DNSServer dnsServer;
 Languages language = EN;
 
@@ -283,7 +277,7 @@ void setup()
     intervalometer.readPresetsFromEEPROM();
 #ifdef AP
     WiFi.mode(WIFI_MODE_AP);
-    WiFi.softAP(ssid, password);
+    WiFi.softAP(WIFI_SSID, WIFI_PASSWORD);
     delay(500);
     Serial.println("Creating Wifi Network");
 
@@ -304,7 +298,7 @@ void setup()
     // ANDROID 10 WORKAROUND==================================================
 #else
     WiFi.mode(WIFI_MODE_STA); // Set ESP32 in station mode
-    WiFi.begin(ssid, password);
+    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
     Serial.println("Connecting to Network in STA mode");
     while (WiFi.status() != WL_CONNECTED)
     {
@@ -314,7 +308,7 @@ void setup()
 #endif
     dnsServer.setTTL(300);
     dnsServer.setErrorReplyCode(DNSReplyCode::ServerFailure);
-    dnsServer.start(DNS_PORT, website_name, WiFi.softAPIP());
+    dnsServer.start(DNS_PORT, WEBSITE_NAME, WiFi.softAPIP());
 
     server.on("/", HTTP_GET, handleRoot);
     server.on("/on", HTTP_GET, handleOn);

--- a/esp32_wireless_control/firmware/platformio.ini
+++ b/esp32_wireless_control/firmware/platformio.ini
@@ -35,4 +35,9 @@ build_flags =
     -D VERSION=${ogstartracker.custom_version}
     -D DEBUG=0
     -D BUILD_VERSION=\"${ogstartracker.custom_version}\"
+    -D WIFI_SSID='"OG Star Tracker"'
+    -D WIFI_PASSWORD='"password123"'
+    -D WEBSITE_NAME='"www.tracker.com"'
+    -D DNS_PORT=53
+    -D WEBSERVER_PORT=80
     -Wall -Wextra -Os

--- a/esp32_wireless_control/firmware/platformio.ini
+++ b/esp32_wireless_control/firmware/platformio.ini
@@ -28,7 +28,9 @@ custom_debug_port = \\.\COM5
 
 [env:ogstartracker_release]
 build_type = release
-extra_scripts = pre:shared/versioning.py
+extra_scripts =
+    pre:shared/versioning.py
+    post:shared/generate_compiledb.py
 monitor_speed = 115200
 build_flags =
     -D BINARY_NAME=${ogstartracker.custom_binary_name}

--- a/esp32_wireless_control/firmware/platformio.ini
+++ b/esp32_wireless_control/firmware/platformio.ini
@@ -43,4 +43,6 @@ build_flags =
     -D WEBSITE_NAME='"www.tracker.com"'
     -D DNS_PORT=53
     -D WEBSERVER_PORT=80
+    -D AP_MODE=1
+    -D TRACKING_RATE=TRACKING_SIDEREAL
     -Wall -Wextra -Os

--- a/esp32_wireless_control/firmware/platformio.ini
+++ b/esp32_wireless_control/firmware/platformio.ini
@@ -37,6 +37,7 @@ build_flags =
     -D VERSION=${ogstartracker.custom_version}
     -D DEBUG=0
     -D BUILD_VERSION=\"${ogstartracker.custom_version}\"
+    -D INTERNAL_VERSION=7
     -D WIFI_SSID='"OG Star Tracker"'
     -D WIFI_PASSWORD='"password123"'
     -D WEBSITE_NAME='"www.tracker.com"'

--- a/esp32_wireless_control/firmware/shared/generate_compiledb.py
+++ b/esp32_wireless_control/firmware/shared/generate_compiledb.py
@@ -1,0 +1,6 @@
+Import("env")
+
+def generate_compiledb(env, *args, **kwargs):
+    env.Execute(f"pio run -e {env['PIOENV']} -t compiledb")
+
+env.AddPreAction("buildprog", generate_compiledb)


### PR DESCRIPTION
Some variables were statically defined in the firmware.ino.
Moved them to the `config.h` and additionally expand the build environment in `platformio.ini` with those values.

On top of that let platformio build the `compile_commands.json` for all of those that use the `clang` extension in vscode to step into libraries and provide code highlightings.

Requires #29 #30 #36