### PR TITLE
github: fix formatting check to run on every pull request

### DIFF
--- a/.github/workflows/formatting-check.yaml
+++ b/.github/workflows/formatting-check.yaml
@@ -1,5 +1,7 @@
 name: OGStarTracker CI
-on: [push]
+on: 
+  push:
+
 jobs:
   formatting-check:
     name: Formatting Check


### PR DESCRIPTION
Mistakenly had a old github workflow configuration in preventing the workflow to be run on every pull request.