### PR TITLE
Fix intervalometer and accesspoint startup

### DIFF
--- a/esp32_wireless_control/firmware/firmware.ino
+++ b/esp32_wireless_control/firmware/firmware.ino
@@ -316,8 +316,8 @@ void webserverTask(void* pvParameters)
 #ifdef AP
     WiFi.mode(WIFI_MODE_AP);
     WiFi.softAP(WIFI_SSID, WIFI_PASSWORD);
-    delay(500);
-    Serial.println("Creating Wifi Network");
+    vTaskDelay(500);
+    Serial.println("Creating Wifi Network\r\n");
 
     // ANDROID 10 WORKAROUND==================================================
     // set new WiFi configurations
@@ -332,7 +332,7 @@ void webserverTask(void* pvParameters)
     Serial.println("WiFi: Disabled AMPDU...");
     esp_wifi_init(&my_config); // set the new config = "Disable AMPDU"
     esp_wifi_start();          // Restart WiFi
-    delay(500);
+    vTaskDelay(500);
     // ANDROID 10 WORKAROUND==================================================
 #else
     WiFi.mode(WIFI_MODE_STA); // Set ESP32 in station mode
@@ -340,8 +340,8 @@ void webserverTask(void* pvParameters)
     Serial.println("Connecting to Network in STA mode");
     while (WiFi.status() != WL_CONNECTED)
     {
-        delay(1000);
-        Serial.print(".");
+        vTaskDelay(1000);
+        Serial.println(".");
     }
 #endif
 

--- a/esp32_wireless_control/firmware/firmware.ino
+++ b/esp32_wireless_control/firmware/firmware.ino
@@ -345,7 +345,7 @@ void setup()
     // Initialize Wifi and web server
     setupWireless();
 
-    if (xTaskCreate(intervalometerTask, "intervalometerTask", 2048, NULL, 1, NULL))
+    if (xTaskCreate(intervalometerTask, "intervalometerTask", 4096, NULL, 1, NULL))
         Serial.print("Starting intervalometer task");
     if (xTaskCreate(webserverTask, "webserverTask", 4096, NULL, 1, NULL))
         Serial.print("Starting webserver task");

--- a/esp32_wireless_control/firmware/intervalometer.cpp
+++ b/esp32_wireless_control/firmware/intervalometer.cpp
@@ -114,7 +114,7 @@ void Intervalometer::run()
                 {
                     intervalometerTimer.start(2000, false); // 1 sec should cover day time
                                                             // exposures.
-                    delay(10);
+                    vTaskDelay(10);
                     digitalWrite(triggerPin, LOW);
                 }
                 else


### PR DESCRIPTION
Starting the wifi configuration may lead to race conditions with the current startup so unifying the accesspoint and webserver init gives the system the headroom to work properly.

Additionally replacing delay() with vTaskDelay() keeps the system consistent.
This has been tested on an ESP32S3 DevkitC and worked properly without crashes.