### PR TITLE
add dedicated serial printout task

### DIFF
--- a/esp32_wireless_control/firmware/intervalometer.cpp
+++ b/esp32_wireless_control/firmware/intervalometer.cpp
@@ -61,7 +61,7 @@ void Intervalometer::run()
     switch (currentState)
     {
         case INACTIVE:
-            // print_out(INACTIVE);
+            print_out("Intervalometer: INACTIVE");
             ra_axis.stopSlew();
             intervalometerTimer.stop();
             digitalWrite(triggerPin, LOW);
@@ -81,7 +81,7 @@ void Intervalometer::run()
 
             if (!timerStarted)
             {
-                // print_out("PREDELAY_START");
+                print_out("Intervalometer: PREDELAY_START");
                 if ((currentSettings.mode == DAY_TIME_LAPSE ||
                      currentSettings.mode == DAY_TIME_LAPSE_PAN) &&
                     ra_axis.trackingActive)
@@ -96,7 +96,7 @@ void Intervalometer::run()
             if (nextState)
             {
                 intervalometerTimer.stop();
-                // print_out("PREDELAY_STOP");
+                print_out("Intervalometer: PREDELAY_STOP");
                 nextState = false;
                 timerStarted = false;
                 currentState = CAPTURE;
@@ -105,7 +105,7 @@ void Intervalometer::run()
         case CAPTURE:
             if (!timerStarted)
             { // nightime modes
-                // print_out("capture_start");
+                print_out("Intervalometer: capture_start");
                 if (currentSettings.mode == LONG_EXPOSURE_MOVIE && !ra_axis.counterActive)
                 {
                     ra_axis.resetAxisCount();
@@ -129,7 +129,7 @@ void Intervalometer::run()
             {
                 digitalWrite(triggerPin, LOW);
                 intervalometerTimer.stop();
-                // print_out("capture_end");
+                print_out("Intervalometer: capture_end");
                 nextState = false;
                 timerStarted = false;
                 exposures_taken++;
@@ -143,7 +143,7 @@ void Intervalometer::run()
             {
                 if (!axisMoving)
                 {
-                    // print_out("dither_start");
+                    print_out("Intervalometer: dither_start");
                     axisMoving = true;
                     uint8_t randomDirection = biasedRandomDirection(previousDitherDirection);
                     previousDitherDirection = randomDirection;
@@ -162,7 +162,7 @@ void Intervalometer::run()
                 }
                 if (!ra_axis.slewActive)
                 {
-                    // print_out("dither_end");
+                    print_out("Intervalometer: dither_end");
                     if (currentSettings.mode != LONG_EXPOSURE_MOVIE)
                     {
                         ra_axis.counterActive = false;
@@ -179,7 +179,7 @@ void Intervalometer::run()
         case PAN:
             if (!axisMoving)
             {
-                // print_out("pan_start");
+                print_out("Intervalometer: pan_start");
                 axisMoving = true;
                 uint64_t arcSecsToMove = uint64_t(3600.0 * currentSettings.panAngle);
                 int64_t stepsToMove = currentSettings.panDirection
@@ -197,7 +197,7 @@ void Intervalometer::run()
             }
             if (!ra_axis.slewActive)
             {
-                // print_out("pan_end");
+                print_out("Intervalometer: pan_end");
                 axisMoving = false;
                 ra_axis.counterActive = false;
                 ra_axis.goToTarget = false;
@@ -215,14 +215,14 @@ void Intervalometer::run()
             {
                 if (!timerStarted)
                 {
-                    // print_out("delay_start");
+                    print_out("Intervalometer: delay_start");
                     intervalometerTimer.start(2000 * currentSettings.delayTime, false);
                     timerStarted = true;
                 }
                 if (nextState)
                 {
                     intervalometerTimer.stop();
-                    // print_out("delay_end");
+                    print_out("Intervalometer: delay_end");
                     nextState = false;
                     timerStarted = false;
                     currentState = CAPTURE;
@@ -233,7 +233,7 @@ void Intervalometer::run()
         case REWIND:
             if (!axisMoving)
             {
-                // print_out("rewind_start");
+                print_out("Intervalometer: rewind_start");
                 axisMoving = true;
                 exposures_taken = 0;
                 frames_taken++;
@@ -247,7 +247,7 @@ void Intervalometer::run()
             }
             if (!ra_axis.slewActive)
             {
-                // print_out("rewind_end");
+                print_out("Intervalometer: rewind_end");
                 axisMoving = false;
                 currentState = CAPTURE;
             }

--- a/esp32_wireless_control/firmware/intervalometer.cpp
+++ b/esp32_wireless_control/firmware/intervalometer.cpp
@@ -1,6 +1,7 @@
 #include "esp32-hal-gpio.h"
 // #include <cstdlib>
 #include "intervalometer.h"
+#include "uart.h"
 
 void intervalometer_ISA()
 {
@@ -60,7 +61,7 @@ void Intervalometer::run()
     switch (currentState)
     {
         case INACTIVE:
-            // Serial.println(INACTIVE);
+            // print_out(INACTIVE);
             ra_axis.stopSlew();
             intervalometerTimer.stop();
             digitalWrite(triggerPin, LOW);
@@ -80,7 +81,7 @@ void Intervalometer::run()
 
             if (!timerStarted)
             {
-                // Serial.println("PREDELAY_START");
+                // print_out("PREDELAY_START");
                 if ((currentSettings.mode == DAY_TIME_LAPSE ||
                      currentSettings.mode == DAY_TIME_LAPSE_PAN) &&
                     ra_axis.trackingActive)
@@ -95,7 +96,7 @@ void Intervalometer::run()
             if (nextState)
             {
                 intervalometerTimer.stop();
-                // Serial.println("PREDELAY_STOP");
+                // print_out("PREDELAY_STOP");
                 nextState = false;
                 timerStarted = false;
                 currentState = CAPTURE;
@@ -104,7 +105,7 @@ void Intervalometer::run()
         case CAPTURE:
             if (!timerStarted)
             { // nightime modes
-                // Serial.println("capture_start");
+                // print_out("capture_start");
                 if (currentSettings.mode == LONG_EXPOSURE_MOVIE && !ra_axis.counterActive)
                 {
                     ra_axis.resetAxisCount();
@@ -128,7 +129,7 @@ void Intervalometer::run()
             {
                 digitalWrite(triggerPin, LOW);
                 intervalometerTimer.stop();
-                // Serial.println("capture_end");
+                // print_out("capture_end");
                 nextState = false;
                 timerStarted = false;
                 exposures_taken++;
@@ -142,7 +143,7 @@ void Intervalometer::run()
             {
                 if (!axisMoving)
                 {
-                    // Serial.println("dither_start");
+                    // print_out("dither_start");
                     axisMoving = true;
                     uint8_t randomDirection = biasedRandomDirection(previousDitherDirection);
                     previousDitherDirection = randomDirection;
@@ -161,7 +162,7 @@ void Intervalometer::run()
                 }
                 if (!ra_axis.slewActive)
                 {
-                    // Serial.println("dither_end");
+                    // print_out("dither_end");
                     if (currentSettings.mode != LONG_EXPOSURE_MOVIE)
                     {
                         ra_axis.counterActive = false;
@@ -178,7 +179,7 @@ void Intervalometer::run()
         case PAN:
             if (!axisMoving)
             {
-                // Serial.println("pan_start");
+                // print_out("pan_start");
                 axisMoving = true;
                 uint64_t arcSecsToMove = uint64_t(3600.0 * currentSettings.panAngle);
                 int64_t stepsToMove = currentSettings.panDirection
@@ -196,7 +197,7 @@ void Intervalometer::run()
             }
             if (!ra_axis.slewActive)
             {
-                // Serial.println("pan_end");
+                // print_out("pan_end");
                 axisMoving = false;
                 ra_axis.counterActive = false;
                 ra_axis.goToTarget = false;
@@ -214,14 +215,14 @@ void Intervalometer::run()
             {
                 if (!timerStarted)
                 {
-                    // Serial.println("delay_start");
+                    // print_out("delay_start");
                     intervalometerTimer.start(2000 * currentSettings.delayTime, false);
                     timerStarted = true;
                 }
                 if (nextState)
                 {
                     intervalometerTimer.stop();
-                    // Serial.println("delay_end");
+                    // print_out("delay_end");
                     nextState = false;
                     timerStarted = false;
                     currentState = CAPTURE;
@@ -232,7 +233,7 @@ void Intervalometer::run()
         case REWIND:
             if (!axisMoving)
             {
-                // Serial.println("rewind_start");
+                // print_out("rewind_start");
                 axisMoving = true;
                 exposures_taken = 0;
                 frames_taken++;
@@ -246,7 +247,7 @@ void Intervalometer::run()
             }
             if (!ra_axis.slewActive)
             {
-                // Serial.println("rewind_end");
+                // print_out("rewind_end");
                 axisMoving = false;
                 currentState = CAPTURE;
             }
@@ -267,14 +268,14 @@ void Intervalometer::readSettingsFromPreset(uint8_t preset)
 
 void Intervalometer::savePresetsToEEPPROM()
 {
-    Serial.print("writtenBytes: ");
-    Serial.println(writeObjectToEEPROM(PRESETS_EEPROM_START_LOCATION, presets));
+    print_out("writtenBytes: ");
+    print_out("%d", writeObjectToEEPROM(PRESETS_EEPROM_START_LOCATION, presets));
 }
 
 void Intervalometer::readPresetsFromEEPROM()
 {
-    Serial.print("readBytes: ");
-    Serial.println(readObjectFromEEPROM(PRESETS_EEPROM_START_LOCATION, presets));
+    print_out("readBytes: ");
+    print_out("%d", readObjectFromEEPROM(PRESETS_EEPROM_START_LOCATION, presets));
 }
 
 uint16_t Intervalometer::getStepsPerTenPixels()
@@ -305,10 +306,10 @@ template <class T> int Intervalometer::writeObjectToEEPROM(int address, const T&
     unsigned int i;
     for (i = 0; i < sizeof(object); i++)
     {
-        // Serial.print("Address = ");
-        // Serial.print(address);
-        // Serial.print(", Data = ");
-        // Serial.println(*p);
+        // print_out("Address = ");
+        // print_out(address);
+        // print_out(", Data = ");
+        // print_out(*p);
         EEPROM.write(address++, *p++);
         EEPROM.commit();
     }
@@ -322,10 +323,10 @@ template <class T> int Intervalometer::readObjectFromEEPROM(int address, T& obje
     unsigned int i;
     for (i = 0; i < sizeof(object); i++)
     {
-        // Serial.print("Address = ");
-        // Serial.print(address);
-        // Serial.print(", Data = ");
-        // Serial.println(EEPROM.read(address), HEX);
+        // print_out("Address = ");
+        // print_out(address);
+        // print_out(", Data = ");
+        // print_out(EEPROM.read(address), HEX);
         *p++ = EEPROM.read(address++);
     }
     return i;

--- a/esp32_wireless_control/firmware/intervalometer.h
+++ b/esp32_wireless_control/firmware/intervalometer.h
@@ -43,16 +43,16 @@ class Intervalometer
     uint8_t previousDitherDirection;
 
     struct Settings
-    { // 20 bytes
-        Mode mode;
+    {                            // 28 bytes
+        Mode mode;               // 4b
         uint16_t exposures;      // 2b
         uint16_t delayTime;      // seconds, max limt 18 h, 12 mins //2b
         uint16_t preDelay;       // seconds //2b
         uint16_t exposureTime;   // seconds, max limt 18 h, 12 mins //2b
         float panAngle;          // degrees //4b
-        bool panDirection;       //
+        bool panDirection;       // 1b
         bool dither;             // 1b
-        uint8_t ditherFrequency; //
+        uint8_t ditherFrequency; // 1b
         bool enableTracking;     // 1b
         uint16_t frames;         // 2b
         float pixelSize;         // micrometre (um) //4b


### PR DESCRIPTION
Add abstraction layer for the serial printouts in a seperate task.
All `Serial.print` calls are replaced with `print_out` as provided by the `uart.h`. Allthough it is not a class yet this can be expanded for other features likes loglevel or similiar.

Additionally print the current intervalometer state to have a slight idea whats going on on the system. 