### PR TITLE
Moved startTracking() call to setup() 

### DIFF
--- a/esp32_wireless_control/firmware/axis.cpp
+++ b/esp32_wireless_control/firmware/axis.cpp
@@ -60,11 +60,6 @@ Axis::Axis(uint8_t axis, uint8_t dirPinforAxis, bool invertDirPin) : stepTimer(4
             stepTimer.attachInterupt(&stepTimerDEC_ISR);
             break;
     }
-
-    if (DEFAULT_ENABLE_TRACKING == 1 && axisNumber == 1)
-    {
-        startTracking(trackingRate, trackingDirection);
-    }
 }
 
 void Axis::startTracking(trackingRateS rate, bool directionArg)

--- a/esp32_wireless_control/firmware/axis.h
+++ b/esp32_wireless_control/firmware/axis.h
@@ -27,6 +27,9 @@ class Axis
   public:
     Axis(uint8_t axisNumber, uint8_t dirPinforAxis, bool invertDirPin);
     void startTracking(trackingRateS rate, bool directionArg);
+    void startTracking() {
+        startTracking(trackingRate, trackingDirection);
+     }
     void stopTracking();
     void startSlew(uint64_t rate, bool directionArg);
     void stopSlew();

--- a/esp32_wireless_control/firmware/firmware.ino
+++ b/esp32_wireless_control/firmware/firmware.ino
@@ -448,14 +448,22 @@ void setup()
     digitalWrite(EN12_n, LOW);
     // handleExposureSettings();
 
-    // Initialize Wifi and web server
-    setupWireless();
-
     if (xTaskCreate(uartTask, "UartTask", 4096, NULL, 1, NULL))
     {
         print_out("\033c");
         print_out("Starting uart task");
     }
+
+    // Start tracking axis now that pins and UART is initialized
+#if defined(DEFAULT_ENABLE_TRACKING) && (DEFAULT_ENABLE_TRACKING == 1)
+    print_out(c_DIRECTION ? "Tracking with c_DIRECTION: HIGH (North)"
+                          : "Tracking with c_DIRECTION: LOW (South)");
+    ra_axis.startTracking();
+#endif // DEFAULT_ENABLE_TRACKING
+
+    // Initialize Wifi and web server
+    setupWireless();
+
     if (xTaskCreate(intervalometerTask, "intervalometerTask", 4096, NULL, 1, NULL))
         print_out("Starting intervalometer task");
     if (xTaskCreatePinnedToCore(webserverTask, "webserverTask", 4096, NULL, 1, NULL, 0))


### PR DESCRIPTION
I'm working with a OG v1. In my setup I was getting tracking rotation in the wrong direction. I found this to be due to pin initialization in `setup()` occurring after the code in the static `Axis ra_axis` constructor had executed, with `setDirection` failing. For the same reason, outputting to UART was also failing since it's initialized in `setup()` as well.

Moving the `startTracking()` call to setup resolved these issues.