### PR TITLE
add minimalistic commandline interface

### DIFF
--- a/esp32_wireless_control/firmware/axis.h
+++ b/esp32_wireless_control/firmware/axis.h
@@ -6,7 +6,7 @@
 
 extern HardwareTimer slewTimeOut;
 
-#ifdef STEPPER_0_9
+#if STEPPER_TYPE == STEPPER_0_9
 enum trackingRateS
 {
     TRACKING_SIDEREAL = 2659383, // SIDEREAL (23h,56 min)

--- a/esp32_wireless_control/firmware/commands.cpp
+++ b/esp32_wireless_control/firmware/commands.cpp
@@ -1,0 +1,157 @@
+#include <freertos/FreeRTOS.h>
+
+#include <commands.h>
+#include <uart.h>
+
+SerialTerminal* _term;
+
+extern QueueHandle_t msgq;
+
+enum task_names : uint8_t
+{
+    UART_TASK,
+    CONSOLE_TASK,
+    INTERVALOMETER_TASK,
+    WEBSERVER_TASK,
+    DNSSERVER_TASK,
+};
+
+static void cmdHelp()
+{
+    // Print usage
+    print_out_tbl(CMD_HELP_TITLE);
+    print_out_tbl(CMD_HELP_HELP);
+    print_out_tbl(CMD_HELP_STACK);
+    print_out_tbl(CMD_HELP_HEAP);
+    print_out_tbl(CMD_HELP_RESET);
+}
+
+static uint16_t get_stack_high_water(const char* task_name)
+{
+    TaskHandle_t task = xTaskGetHandle(task_name);
+    uint16_t stack_size = 0;
+
+    if (task == NULL)
+        print_out(tsk_not_avail);
+    else
+    {
+        configASSERT(task);
+        stack_size = uxTaskGetStackHighWaterMark(task);
+    }
+    return stack_size;
+}
+
+static void cmdStackAvailable()
+{
+    // Print available stack
+    int argIndex = 0;
+    char* arg;
+
+    // Print arguments
+    for (argIndex = 0; argIndex < 8; argIndex++)
+    {
+        arg = _term->getNext();
+        if (arg != NULL)
+        {
+            switch (atoi(arg))
+            {
+                case UART_TASK:
+                    print_out_tbl(CMD_STACK_HIGHWATER_UART);
+                    print_out("%d Bytes", get_stack_high_water("uart"));
+                    break;
+                case CONSOLE_TASK:
+                    print_out_tbl(CMD_STACK_HIGHWATER_CONSOLE);
+                    print_out("%d Bytes", get_stack_high_water("console"));
+                    break;
+                case INTERVALOMETER_TASK:
+                    print_out_tbl(CMD_STACK_HIGHWATER_INTERVALOMETER);
+                    print_out("%d Bytes", get_stack_high_water("intervalometer"));
+                    break;
+                case WEBSERVER_TASK:
+                    print_out_tbl(CMD_STACK_HIGHWATER_WEBSERVER);
+                    print_out("%d Bytes", get_stack_high_water("webserver"));
+                    break;
+                case DNSSERVER_TASK:
+                    print_out_tbl(CMD_STACK_HIGHWATER_DNSSERVER);
+                    print_out("%d Bytes", get_stack_high_water("dnsserver"));
+                    break;
+                default:
+                    print_out("Task %d not found", atoi(arg));
+                    break;
+            }
+        }
+        else
+        {
+            break;
+        }
+    }
+}
+
+static void cmdHeapAvailable()
+{
+    // Print heap usage
+    char* arg;
+
+    arg = _term->getNext();
+
+    if (arg != NULL)
+    {
+        if (strcmp(arg, "all") == 0)
+        {
+            print_out_tbl(CMD_HEAP_MINIMUM_EVER_FREE);
+            print_out("%d", ESP.getMinFreeHeap());
+        }
+        else
+        {
+            print_out_tbl(CMD_UNKNOWN_ARGUMENT);
+            print_out("%s", arg);
+            print_out_tbl(CMD_HEAP_AVAILABLE_ARGS);
+        }
+    }
+    else
+    {
+        print_out_tbl(CMD_HEAP_FREE);
+        print_out("%d", ESP.getFreeHeap());
+    }
+}
+
+/**
+ * Software reset
+ */
+void (*resetFunc)(void) = 0; // declare reset fuction at address 0
+static void cmdReset()
+{
+    // Reset controller
+    resetFunc();
+}
+
+static void unknownCommand(const char* command)
+{
+    // Print unknown command
+    print_out_tbl(CMD_UNKNOWN_COMMAND);
+    print_out("%s", command);
+}
+
+static void postCommandHandler()
+{
+    // Print '> ' for a primitive user UI
+    print_out_nonl("> ");
+}
+
+void setup_terminal(SerialTerminal* term)
+{
+    // Initialize terminal
+    _term = term;
+
+    // Set default handler for unknown commands
+    _term->setDefaultHandler(unknownCommand);
+    // Set handler to be run AFTER a command has been handled.
+    _term->setPostCommandHandler(postCommandHandler);
+    _term->setSerialEcho(true); // Enable Character Echoing
+    // Add command callback handlers
+    _term->addCommand("?", cmdHelp);
+    _term->addCommand("help", cmdHelp);
+    _term->addCommand("stack", cmdStackAvailable);
+    _term->addCommand("heap", cmdHeapAvailable);
+    _term->addCommand("reset", cmdReset);
+}

--- a/esp32_wireless_control/firmware/commands.h
+++ b/esp32_wireless_control/firmware/commands.h
@@ -1,0 +1,19 @@
+/**
+ * @file commands.h
+ * @version 0.1.0
+ *
+ * @section License
+ * Copyright (C) 2025, Sylensky
+ */
+
+#ifndef COMMANDS_H
+#define COMMANDS_H
+
+#include <Arduino.h>
+#include <ErriezSerialTerminal.h>
+
+#include <common_strings.h>
+
+void setup_terminal(SerialTerminal* term);
+
+#endif // COMMANDS_H

--- a/esp32_wireless_control/firmware/common_strings.h
+++ b/esp32_wireless_control/firmware/common_strings.h
@@ -1,0 +1,48 @@
+#ifndef COMMAND_STRINGS_H
+#define COMMAND_STRINGS_H
+
+/* clang-format off */
+// headline
+static const char head_line[] = "******************************************\r\n";
+static const char head_line_debug[] = "***************Debug Build****************\r\n";
+static const char head_line_version[] = "***     " BUILD_VERSION "  " __DATE__ "  " __TIME__ "    ***\r\n";
+static const char head_line_tracker[] = "***         Starting Tracker Up        ***\r\n";
+
+// general purpose
+static const char malloc_failed[] = "Malloc failed!\r\n";
+static const char not_supported[] = "not supported on this device\r\n";
+static const char str_true[] = "true";
+static const char str_false[] = "false";
+static const char cr_nl[] = "\r\n";
+
+const char* const string_table[] = {
+    // headline
+    head_line,
+    head_line_debug,
+    head_line_version,
+    head_line_tracker,
+
+    // general purpose
+    malloc_failed,
+    not_supported,
+    str_true,
+    str_false,
+    cr_nl,
+};
+/* clang-format on */
+
+enum pgm_table_index_t
+{
+    HEAD_LINE,
+    HEAD_LINE_DEBUG,
+    HEAD_LINE_VERSION,
+    HEAD_LINE_TRACKER,
+
+    MALLOC_FAILED,
+    NOT_SUPPORTED,
+    STR_TRUE,
+    STR_FALSE,
+    CR_NL,
+};
+
+#endif

--- a/esp32_wireless_control/firmware/common_strings.h
+++ b/esp32_wireless_control/firmware/common_strings.h
@@ -8,6 +8,36 @@ static const char head_line_debug[] = "***************Debug Build***************
 static const char head_line_version[] = "***     " BUILD_VERSION "  " __DATE__ "  " __TIME__ "    ***\r\n";
 static const char head_line_tracker[] = "***         Starting Tracker Up        ***\r\n";
 
+// command line interface
+static const char cmd_no_input[] = "No input to send - skipping\r\n";
+static const char cmd_insufficient_args[] = "  Unsufficient arguments provided - skipping\r\n";
+static const char cmd_unknown_argument[] = "Unknown argument: ";
+static const char cmd_unknown_command[] = "Unknown command: ";
+static const char cmd_heap_minimum_ever_free[] = "Minimum Heap (Bytes): ";
+static const char cmd_heap_free[] = "Free heap (Bytes): ";
+static const char cmd_heap_available_args[] = "Available args: all\r\n";
+
+static const char cmd_stack_highwater_uart[] = "Uart stack highwater: ";
+static const char cmd_stack_highwater_console[] = "Console stack highwater: ";
+static const char cmd_stack_highwater_intervalometer[] = "Intervalometer stack highwater: ";
+static const char cmd_stack_highwater_webserver[] = "Webserver stack highwater: ";
+static const char cmd_stack_highwater_dnsserver[] = "DNSserver stack highwater: ";
+
+static const char cmd_help_title[] = "Serial terminal usage:\r\n";
+static const char cmd_help_help[] = "  help or ?                      Print this usage\r\n";
+static const char cmd_help_stack[] = "  stack <0..N task>              Print available stack\r\n";
+static const char cmd_help_heap[] = "  heap <all>                     Print free heap\r\n";
+static const char cmd_help_reset[] = "  reset                          Reset the controller\r\n";
+
+// task related
+static const char tsk_not_avail[] = "task not available\r\n";
+static const char tsk_clear_screen[] = "\033c";
+static const char tsk_start_uart[] = "started uartTask\r\n";
+static const char tsk_start_console[] = "started ConsoleTask\r\n";
+static const char tsk_start_intervalometer[] = "started IntervalometerTask\r\n";
+static const char tsk_start_webserver[] = "started WebserverTask\r\n";
+static const char tsk_start_dnsserver[] = "started DNSserverTask\r\n";
+
 // general purpose
 static const char malloc_failed[] = "Malloc failed!\r\n";
 static const char not_supported[] = "not supported on this device\r\n";
@@ -21,6 +51,36 @@ const char* const string_table[] = {
     head_line_debug,
     head_line_version,
     head_line_tracker,
+
+    // command line interface
+    cmd_no_input,
+    cmd_insufficient_args,
+    cmd_unknown_argument,
+    cmd_unknown_command,
+    cmd_heap_minimum_ever_free,
+    cmd_heap_free,
+    cmd_heap_available_args,
+
+    cmd_stack_highwater_uart,
+    cmd_stack_highwater_console,
+    cmd_stack_highwater_intervalometer,
+    cmd_stack_highwater_webserver,
+    cmd_stack_highwater_dnsserver,
+
+    cmd_help_title,
+    cmd_help_help,
+    cmd_help_stack,
+    cmd_help_heap,
+    cmd_help_reset,
+
+    // task related
+    tsk_not_avail,
+    tsk_clear_screen,
+    tsk_start_uart,
+    tsk_start_console,
+    tsk_start_intervalometer,
+    tsk_start_webserver,
+    tsk_start_dnsserver,
 
     // general purpose
     malloc_failed,
@@ -37,6 +97,34 @@ enum pgm_table_index_t
     HEAD_LINE_DEBUG,
     HEAD_LINE_VERSION,
     HEAD_LINE_TRACKER,
+
+    CMD_NO_INPUT,
+    CMD_INSUFFICIENT_ARGS,
+    CMD_UNKNOWN_ARGUMENT,
+    CMD_UNKNOWN_COMMAND,
+    CMD_HEAP_MINIMUM_EVER_FREE,
+    CMD_HEAP_FREE,
+    CMD_HEAP_AVAILABLE_ARGS,
+
+    CMD_STACK_HIGHWATER_UART,
+    CMD_STACK_HIGHWATER_CONSOLE,
+    CMD_STACK_HIGHWATER_INTERVALOMETER,
+    CMD_STACK_HIGHWATER_WEBSERVER,
+    CMD_STACK_HIGHWATER_DNSSERVER,
+
+    CMD_HELP_TITLE,
+    CMD_HELP_HELP,
+    CMD_HELP_STACK,
+    CMD_HELP_HEAP,
+    CMD_HELP_RESET,
+
+    TSK_NOT_AVAIL,
+    TSK_CLEAR_SCREEN,
+    TSK_START_UART,
+    TSK_START_CONSOLE,
+    TSK_START_INTERVALOMETER,
+    TSK_START_WEBSERVER,
+    TSK_START_DNSSERVER,
 
     MALLOC_FAILED,
     NOT_SUPPORTED,

--- a/esp32_wireless_control/firmware/config.h
+++ b/esp32_wireless_control/firmware/config.h
@@ -1,6 +1,9 @@
 #ifndef CONFIG
 #define CONFIG
 
+#define STEPPER_0_9 0 // 0.9 degree stepper motor
+#define STEPPER_1_8 1 // 1.8 degree stepper motor
+
 /*To build in Arduino IDE, install esp32 boards V3.0x and the Arduinojson library by Benoit
  * Blanchon*/
 /*****USER DEFINED*****/
@@ -13,9 +16,6 @@
 #define DITHER_DISTANCE_X10_PIXELS 5 // set max distance to dither in multiple of 10 pixels
 #define MAX_CUSTOM_SLEW_RATE 400     // Set max custom slew rate to X tracking rate
 #define MIN_CUSTOM_SLEW_RATE 2       // Set min custom slew rate to X tracking rate
-#define STEPPER_0_9                  // uncomment this line if you have a 0.9 degree NEMA17
-// #define STEPPER_1_8   //uncomment this line if you have a 1.8 degree NEMA17, and comment the
-// above line
 
 #ifndef TRACKING_RATE
 // Available tracking rates:
@@ -25,6 +25,10 @@
 #define TRACKING_RATE TRACKING_SIDEREAL // default tracking rate
 #endif
 
+// Configure the stepper motor type
+#ifndef STEPPER_TYPE
+#define STEPPER_TYPE STEPPER_0_9 // 0.9 degree stepper motor
+#endif
 // Configure the wifi settings if you are not using platformio
 #ifndef WIFI_SSID
 #define WIFI_SSID "OG Star Tracker" // change to your SSID

--- a/esp32_wireless_control/firmware/firmware.ino
+++ b/esp32_wireless_control/firmware/firmware.ino
@@ -1,5 +1,6 @@
 #include <ArduinoJson.h>
 #include <DNSServer.h>
+#include <ErriezSerialTerminal.h>
 #include <WebServer.h>
 #include <WiFi.h>
 #include <esp_wifi.h>
@@ -7,6 +8,7 @@
 #include <string.h>
 
 #include "axis.h"
+#include "common_strings.h"
 #include "config.h"
 #include "hardwaretimer.h"
 #include "index_html.h"
@@ -15,6 +17,7 @@
 #include "web_languages.h"
 #include "website_strings.h"
 
+SerialTerminal term(CLI_NEWLINE_CHAR, CLI_DELIMITER_CHAR);
 WebServer server(WEBSERVER_PORT);
 DNSServer dnsServer;
 Languages language = EN;
@@ -428,6 +431,12 @@ void setup()
 {
     // Start the debug serial connection
     setup_uart(&Serial, 115200);
+
+    print_out_tbl(HEAD_LINE);
+    print_out_tbl(HEAD_LINE_TRACKER);
+    print_out("***         Running on %d MHz         ***\r\n", getCpuFrequencyMhz());
+    print_out_tbl(HEAD_LINE_VERSION);
+
     EEPROM.begin(512); // SIZE = 5 x presets = 5 x 32 bytes = 160 bytes
     uint8_t langNum = EEPROM.read(LANG_EEPROM_ADDR);
 
@@ -453,9 +462,10 @@ void setup()
 
     if (xTaskCreate(uartTask, "UartTask", 4096, NULL, 1, NULL))
     {
-        print_out("\033c");
-        print_out("Starting uart task");
+        print_out_tbl(TSK_CLEAR_SCREEN);
+        print_out_tbl(TSK_START_UART);
     }
+
     if (xTaskCreate(intervalometerTask, "intervalometerTask", 4096, NULL, 1, NULL))
         print_out("Starting intervalometer task");
     if (xTaskCreatePinnedToCore(webserverTask, "webserverTask", 4096, NULL, 1, NULL, 0))

--- a/esp32_wireless_control/firmware/intervalometer.h
+++ b/esp32_wireless_control/firmware/intervalometer.h
@@ -7,7 +7,7 @@
 #include "hardwaretimer.h"
 #include <EEPROM.h>
 
-#ifdef STEPPER_0_9
+#if STEPPER_TYPE == STEPPER_0_9
 #define ARCSEC_PER_STEP 2.0
 #else
 #define ARCSEC_PER_STEP 4.0

--- a/esp32_wireless_control/firmware/platformio.ini
+++ b/esp32_wireless_control/firmware/platformio.ini
@@ -19,7 +19,9 @@ board_build.f_cpu = 240000000L
 upload_protocol = esptool
 upload_speed = 921600
 framework = arduino
-lib_deps = bblanchon/ArduinoJson@^7.2.1
+lib_deps =
+    bblanchon/ArduinoJson@^7.2.1
+    erriez/ErriezSerialTerminal@^1.1.4
 
 [ogstartracker]
 custom_binary_name = "ogstartracker"

--- a/esp32_wireless_control/firmware/platformio.ini
+++ b/esp32_wireless_control/firmware/platformio.ini
@@ -41,6 +41,7 @@ build_flags =
     -D WIFI_SSID='"OG Star Tracker"'
     -D WIFI_PASSWORD='"password123"'
     -D WEBSITE_NAME='"www.tracker.com"'
+    -D STEPPER_TYPE=STEPPER_0_9
     -D DNS_PORT=53
     -D WEBSERVER_PORT=80
     -D AP_MODE=1

--- a/esp32_wireless_control/firmware/uart.cpp
+++ b/esp32_wireless_control/firmware/uart.cpp
@@ -32,6 +32,17 @@ void print_out(const char* format, ...)
     xQueueSend(uartq, tra_uart_buffer, portMAX_DELAY);
 }
 
+void print_out_nonl(const char* format, ...)
+{
+    va_list args;
+
+    va_start(args, format);
+    vsnprintf(tra_uart_buffer, MAX_UART_LINE_LEN, format, args);
+    va_end(args);
+
+    xQueueSend(uartq, tra_uart_buffer, portMAX_DELAY);
+}
+
 void print_out_tbl(uint8_t index)
 {
     char tra_uart_buffer[MAX_UART_LINE_LEN];

--- a/esp32_wireless_control/firmware/uart.cpp
+++ b/esp32_wireless_control/firmware/uart.cpp
@@ -6,7 +6,9 @@
  * Copyright (C) 2025, Sylensky
  */
 #include <Arduino.h>
+#include <cstring>
 
+#include <common_strings.h>
 #include <uart.h>
 
 QueueHandle_t uartq;
@@ -26,6 +28,14 @@ void print_out(const char* format, ...)
     va_end(args);
 
     strcat(tra_uart_buffer, "\r\n");
+
+    xQueueSend(uartq, tra_uart_buffer, portMAX_DELAY);
+}
+
+void print_out_tbl(uint8_t index)
+{
+    char tra_uart_buffer[MAX_UART_LINE_LEN];
+    strcpy(tra_uart_buffer, string_table[index]);
 
     xQueueSend(uartq, tra_uart_buffer, portMAX_DELAY);
 }

--- a/esp32_wireless_control/firmware/uart.h
+++ b/esp32_wireless_control/firmware/uart.h
@@ -9,10 +9,17 @@
 #ifndef UART_H
 #define UART_H
 #include <Arduino.h>
+#include <ErriezSerialTerminal.h>
 
 #define MAX_UART_LINE_LEN 128
 
+#define CLI_DELIMITER_CHAR ' '
+#define CLI_NEWLINE_CHAR '\r'
+
+extern SerialTerminal term;
+
 void print_out(const char* format, ...);
+void print_out_tbl(uint8_t index);
 void setup_uart(HardwareSerial* serial, long baudrate);
 void uart_task();
 

--- a/esp32_wireless_control/firmware/uart.h
+++ b/esp32_wireless_control/firmware/uart.h
@@ -19,6 +19,7 @@
 extern SerialTerminal term;
 
 void print_out(const char* format, ...);
+void print_out_nonl(const char* format, ...);
 void print_out_tbl(uint8_t index);
 void setup_uart(HardwareSerial* serial, long baudrate);
 void uart_task();


### PR DESCRIPTION
This adds a basic command line interface to the tracker. It does not contain alot of commands yet but for now this is the commands that will be available:
- `reset`: Resets the whole controller
- `heap <all>`: display available heap and lowest heap since start
- `stack <0...N>`: display stack size of the available tasks by index.

 