### PR TITLE
calculate tracking rate based on config values

### DIFF
--- a/esp32_wireless_control/firmware/axis.cpp
+++ b/esp32_wireless_control/firmware/axis.cpp
@@ -114,14 +114,14 @@ void axisTask(void* parameter)
 }
 
 Axis::Axis(uint8_t axis, MotorDriver* motorDriver, uint8_t dirPinforAxis, bool invertDirPin)
-    : stepTimer(40000000), startRequested(false)
+    : stepTimer(TIMER_APB_CLK_FREQ), startRequested(false)
 {
     driver = motorDriver;
     axisNumber = axis;
     direction.tracking = c_DIRECTION;
     dirPin = dirPinforAxis;
     invertDirectionPin = invertDirPin;
-    rate.tracking = TRACKING_RATE;
+    rate.tracking = trackingRates.getRate();
 
     pinMode(dirPin, OUTPUT);
 

--- a/esp32_wireless_control/firmware/consts.h
+++ b/esp32_wireless_control/firmware/consts.h
@@ -11,6 +11,31 @@
 
 #define GEAR_RATIO 101.25
 
+// Timer frequency used for hardware timer (40MHz APB clock)
+#define TIMER_APB_CLK_FREQ 40000000UL
+
+// Gear ratio as integers to avoid floating point in enum calculations
+#define GEAR_RATIO_NUM 405 // 101.25 * 4 = 405
+#define GEAR_RATIO_DEN 4   // Denominator = 4
+
+// Motor microstepping configuration
+#define TRACKER_MOTOR_MICROSTEPPING 64
+
+#if STEPPER_TYPE == STEPPER_0_9
+// Define steps per revolution based on stepper type
+#define STEPPER_STEPS_PER_REV 400
+#else
+#define STEPPER_STEPS_PER_REV 200
+#endif
+
 #define STEPS_PER_TRACKER_FULL_REV (STEPPER_STEPS_PER_REV * GEAR_RATIO * MAX_MICROSTEPS)
+
+// Steps per tracker full revolution using integer gear ratio (for enum calculations)
+#define STEPS_PER_TRACKER_FULL_REV_INT                                                             \
+    ((STEPPER_STEPS_PER_REV * GEAR_RATIO_NUM * MAX_MICROSTEPS) / GEAR_RATIO_DEN)
+
+// Steps per second at 256 microstepping for sidereal tracking (calculated from system constants)
+// Formula: STEPS_PER_TRACKER_FULL_REV_INT / SIDERAL_DAY_MS * 1000
+#define STEPS_PER_SECOND_256MICROSTEP ((STEPS_PER_TRACKER_FULL_REV_INT * 1000UL) / SIDERAL_DAY_MS)
 
 #endif /* _CONSTS_H_ */

--- a/esp32_wireless_control/firmware/firmware.ino
+++ b/esp32_wireless_control/firmware/firmware.ino
@@ -64,24 +64,23 @@ void handleRoot()
 void handleOn()
 {
     int tracking_speed = server.arg(TRACKING_SPEED).toInt();
-    trackingRateS rate;
     switch (tracking_speed)
     {
         case 0: // sidereal rate
-            rate = TRACKING_SIDEREAL;
+            trackingRates.setRate(TrackingRateType::TRACKING_SIDEREAL);
             break;
         case 1: // solar rate
-            rate = TRACKING_SOLAR;
+            trackingRates.setRate(TrackingRateType::TRACKING_SOLAR);
             break;
         case 2: // lunar rate
-            rate = TRACKING_LUNAR;
+            trackingRates.setRate(TrackingRateType::TRACKING_LUNAR);
             break;
         default:
-            rate = TRACKING_SIDEREAL;
+            trackingRates.setRate(TrackingRateType::TRACKING_SIDEREAL);
             break;
     }
     int direction = server.arg(DIRECTION).toInt();
-    ra_axis.startTracking(rate, direction);
+    ra_axis.startTracking(trackingRates.getRate(), direction);
 
     if (intervalometer.currentErrorMessage == ErrorMessage::ERR_MSG_NONE)
         server.send(200, MIME_TYPE_TEXT, languageMessageStrings[language][MSG_TRACKING_ON]);

--- a/esp32_wireless_control/firmware/tracking_rates.cpp
+++ b/esp32_wireless_control/firmware/tracking_rates.cpp
@@ -1,0 +1,52 @@
+#include "tracking_rates.h"
+#include "config.h"
+#include "consts.h"
+
+// Calculate tracking rate from period in milliseconds
+// Formula: Timer_reload_value = TIMER_APB_CLK_FREQ / steps_per_second
+// Where steps_per_second = (steps_for_full_revolution_at_64_microstepping) / day_period_in_seconds
+uint64_t TrackingRates::calculateTrackingRate(uint64_t period_ms)
+{
+    // Convert STEPS_PER_TRACKER_FULL_REV_INT from 256 microstepping to 64 microstepping
+    uint64_t steps_per_revolution_microstep =
+        STEPS_PER_TRACKER_FULL_REV_INT / (MAX_MICROSTEPS / TRACKER_MOTOR_MICROSTEPPING);
+
+    // Calculate steps per second for the given period
+    // steps_per_second = steps_per_revolution / period_in_seconds
+    // period_in_seconds = period_ms / 1000
+    double steps_per_second =
+        (double) steps_per_revolution_microstep / ((double) period_ms / 1000.0);
+
+    // Timer reload value = timer_frequency / steps_per_second
+    uint64_t timer_reload_value = (uint64_t) (TIMER_APB_CLK_FREQ / steps_per_second);
+
+    return timer_reload_value;
+}
+
+// Constructor - calculates all tracking rates
+TrackingRates::TrackingRates()
+{
+    sidereal_rate = calculateTrackingRate(SIDERAL_DAY_MS);
+    solar_rate = calculateTrackingRate(SOLAR_DAY_MS);
+    lunar_rate = calculateTrackingRate(LUNAR_DAY_MS);
+    setRate(TRACKING_RATE); // Set initial rate based on TRACKING_RATE
+}
+
+void TrackingRates::setRate(TrackingRateType type)
+{
+    switch (type)
+    {
+        case TRACKING_SIDEREAL:
+            current_rate = sidereal_rate;
+            break;
+        case TRACKING_SOLAR:
+            current_rate = solar_rate;
+            break;
+        case TRACKING_LUNAR:
+            current_rate = lunar_rate;
+            break;
+    }
+};
+
+// Global instance of tracking rates
+TrackingRates trackingRates;

--- a/esp32_wireless_control/firmware/tracking_rates.cpp
+++ b/esp32_wireless_control/firmware/tracking_rates.cpp
@@ -3,8 +3,8 @@
 #include "consts.h"
 
 // Calculate tracking rate from period in milliseconds
-// Formula: Timer_reload_value = TIMER_APB_CLK_FREQ / steps_per_second
-// Where steps_per_second = (steps_for_full_revolution_at_64_microstepping) / day_period_in_seconds
+// Formula: Timer_reload_value = TIMER_APB_CLK_FREQ / timer_interrupts_per_second
+// Where timer_interrupts_per_second = steps_per_second * 2 (ISR toggles HIGH/LOW)
 uint64_t TrackingRates::calculateTrackingRate(uint64_t period_ms)
 {
     // Convert STEPS_PER_TRACKER_FULL_REV_INT from 256 microstepping to 64 microstepping
@@ -17,8 +17,11 @@ uint64_t TrackingRates::calculateTrackingRate(uint64_t period_ms)
     double steps_per_second =
         (double) steps_per_revolution_microstep / ((double) period_ms / 1000.0);
 
-    // Timer reload value = timer_frequency / steps_per_second
-    uint64_t timer_reload_value = (uint64_t) (TIMER_APB_CLK_FREQ / steps_per_second);
+    // ISR creates HIGH/LOW cycle, so we need 2x timer interrupts per stepper step
+    double timer_interrupts_per_second = steps_per_second * 2.0;
+
+    // Timer reload value = timer_frequency / timer_interrupts_per_second
+    uint64_t timer_reload_value = (uint64_t) (TIMER_APB_CLK_FREQ / timer_interrupts_per_second);
 
     return timer_reload_value;
 }

--- a/esp32_wireless_control/firmware/tracking_rates.h
+++ b/esp32_wireless_control/firmware/tracking_rates.h
@@ -2,31 +2,43 @@
 #define _TRACKING_RATES_H_ 1
 
 #include "config.h"
+#include <stdint.h>
 
 #if MOTOR_TRACKING_RATE == TRACKING_RATE_BOARD_V2
-#if STEPPER_TYPE == STEPPER_0_9
-// gear ratio 101.25, 0.9deg motor, 64 msteps, f_cpu@240MHz, f_isr@40MHz
-#define TRACKER_MOTOR_MICROSTEPPING 64
-#define STEPS_PER_SECOND_256MICROSTEP 120
 
-enum trackingRateS
+// Tracking rate enum constants (backward compatible)
+enum TrackingRateType
 {
-    TRACKING_SIDEREAL = 664846, // SIDEREAL (23h,56 min)
-    TRACKING_SOLAR = 666667,    // SOLAR (24h)
-    TRACKING_LUNAR = 680967,    // LUNAR (24h, 31 min)
+    TRACKING_SIDEREAL = 0,
+    TRACKING_SOLAR = 1,
+    TRACKING_LUNAR = 2
 };
-#else // stepper 1.8 deg
-// gear ratio 101.25, 1.8deg motor, 64 msteps, f_cpu@240MHz, f_isr@40MHz
-#define TRACKER_MOTOR_MICROSTEPPING 64
-#define STEPS_PER_SECOND_256MICROSTEP 60
 
-enum trackingRateS
+// Tracking rates class with calculated timer reload values
+class TrackingRates
 {
-    TRACKING_SIDEREAL = 1329691, // SIDEREAL (23h,56 min)
-    TRACKING_SOLAR = 1333333,    // SOLAR (24h)
-    TRACKING_LUNAR = 1361934,    // LUNAR (24h, 31 min)
+  private:
+    uint64_t current_rate;
+    uint64_t sidereal_rate;
+    uint64_t solar_rate;
+    uint64_t lunar_rate;
+
+    // Calculate tracking rate from period in milliseconds
+    uint64_t calculateTrackingRate(uint64_t period_ms);
+
+  public:
+    TrackingRates(); // Constructor calculates all rates
+
+    uint64_t getRate()
+    {
+        return current_rate;
+    };
+    void setRate(TrackingRateType type);
 };
-#endif
+
+// Global instance for easy access
+extern TrackingRates trackingRates;
+
 #else
 #error Unknown tracking rate setting
 #endif


### PR DESCRIPTION
Calculate the tracking rate by using the provided config entries such as gear ratio, isr clock rate, motor type and the maximum applicable microstepping mode.