### PR TITLE
fix goto ra steps/s calculation

### DIFF
--- a/esp32_wireless_control/firmware/axis.cpp
+++ b/esp32_wireless_control/firmware/axis.cpp
@@ -161,6 +161,7 @@ void Axis::gotoTarget(uint64_t rateArg, const Position& current, const Position&
 {
     setMicrostep(TRACKER_MOTOR_MICROSTEPPING / 2);
     int64_t deltaArcseconds = target.arcseconds - current.arcseconds;
+    int64_t stepsPerSecond = trackingRates.getStepsPerSecondSolar();
 
     print_out_nonl("deltaArcseconds: %lld\n", deltaArcseconds);
 
@@ -176,13 +177,13 @@ void Axis::gotoTarget(uint64_t rateArg, const Position& current, const Position&
         }
     }
 
-    int64_t stepsToMove = (deltaArcseconds * STEPS_PER_SECOND_256MICROSTEP) /
-                          (MAX_MICROSTEPS / (microStep ? microStep : 1));
+    int64_t stepsToMove =
+        (deltaArcseconds * stepsPerSecond) / (MAX_MICROSTEPS / (microStep ? microStep : 1));
     bool directionTmp = (stepsToMove < 0) ^ direction.tracking;
 
     print_out_nonl("stepsToMove: %lld\n", stepsToMove);
 
-    setPosition(current.arcseconds * STEPS_PER_SECOND_256MICROSTEP);
+    setPosition(current.arcseconds * stepsPerSecond);
     resetAxisCount();
     setAxisTargetCount(stepsToMove);
 

--- a/esp32_wireless_control/firmware/consts.h
+++ b/esp32_wireless_control/firmware/consts.h
@@ -34,8 +34,4 @@
 #define STEPS_PER_TRACKER_FULL_REV_INT                                                             \
     ((STEPPER_STEPS_PER_REV * GEAR_RATIO_NUM * MAX_MICROSTEPS) / GEAR_RATIO_DEN)
 
-// Steps per second at 256 microstepping for sidereal tracking (calculated from system constants)
-// Formula: STEPS_PER_TRACKER_FULL_REV_INT / SIDERAL_DAY_MS * 1000
-#define STEPS_PER_SECOND_256MICROSTEP ((STEPS_PER_TRACKER_FULL_REV_INT * 1000UL) / SIDERAL_DAY_MS)
-
 #endif /* _CONSTS_H_ */

--- a/esp32_wireless_control/firmware/tracking_rates.cpp
+++ b/esp32_wireless_control/firmware/tracking_rates.cpp
@@ -51,5 +51,21 @@ void TrackingRates::setRate(TrackingRateType type)
     }
 };
 
+// Public functions to get steps per second at 256 microstepping
+uint64_t TrackingRates::getStepsPerSecondSidereal()
+{
+    return ((((uint64_t) STEPS_PER_TRACKER_FULL_REV_INT) * 1000ULL) / SIDERAL_DAY_MS);
+}
+
+uint64_t TrackingRates::getStepsPerSecondSolar()
+{
+    return ((((uint64_t) STEPS_PER_TRACKER_FULL_REV_INT) * 1000ULL) / SOLAR_DAY_MS);
+}
+
+uint64_t TrackingRates::getStepsPerSecondLunar()
+{
+    return ((((uint64_t) STEPS_PER_TRACKER_FULL_REV_INT) * 1000ULL) / LUNAR_DAY_MS);
+}
+
 // Global instance of tracking rates
 TrackingRates trackingRates;

--- a/esp32_wireless_control/firmware/tracking_rates.h
+++ b/esp32_wireless_control/firmware/tracking_rates.h
@@ -34,6 +34,10 @@ class TrackingRates
         return current_rate;
     };
     void setRate(TrackingRateType type);
+
+    uint64_t getStepsPerSecondSidereal();
+    uint64_t getStepsPerSecondSolar();
+    uint64_t getStepsPerSecondLunar();
 };
 
 // Global instance for easy access


### PR DESCRIPTION
Instead of relying on the macro to calculate the steps per second in 256 microstepping mode this introduces class members to calculate the steps in runtime.

requires #69 #70 #68 