### PR TITLE
firmware: axis: Fixed goto RA direction

### DIFF
--- a/esp32_wireless_control/firmware/axis.cpp
+++ b/esp32_wireless_control/firmware/axis.cpp
@@ -160,7 +160,7 @@ void Axis::stopTracking()
 void Axis::gotoTarget(uint64_t rateArg, const Position& current, const Position& target)
 {
     setMicrostep(TRACKER_MOTOR_MICROSTEPPING / 2);
-    int64_t deltaArcseconds = target.arcseconds - current.arcseconds;
+    int64_t deltaArcseconds = -1 * (target.arcseconds - current.arcseconds);
     int64_t stepsPerSecond = trackingRates.getStepsPerSecondSolar();
 
     print_out_nonl("deltaArcseconds: %lld\n", deltaArcseconds);


### PR DESCRIPTION
Fixed goto RA direction to move CCW when doing movement.

NOTICE: the tracker as an internal current position in steps. It might have the positive direction inverted that what we would like it to be.

Right now we are relying on the difference of seconds we want the RA to move. That difference is what we use to move it one direction or the opposite. if we start to rely on the current position of the disc, it might not work as expected.

Some investigation on this issue is required as this fix might shadow another bigger problem.